### PR TITLE
Update UK spelling to United Kingdom

### DIFF
--- a/src/constants/countries.js
+++ b/src/constants/countries.js
@@ -1160,7 +1160,7 @@ const countries = [
     id: '784',
   },
   {
-    name: 'UK',
+    name: 'United Kingdom',
     code: 'GB',
     id: '826',
   },


### PR DESCRIPTION
Update the spelling to the more common form for searching

Fixes https://github.com/tourhero/travel-reopening/issues/9