### PR TITLE
Update-CA-domestic 

### DIFF
--- a/public/data/CA_domestic.md
+++ b/public/data/CA_domestic.md
@@ -6,7 +6,7 @@ Travelers are subject to additional provincial or territorial public health meas
 
 **Ontario**: The government has extended the state of emergency until July 15, 2020.
 
-[Interprovincial travel](https://globalnews.ca/news/7102105/nb-covid-19-update-june-24/) is allowed between **Nova Scotia, New Brunswick, Prince Edward Island, Newfoundland, and Labrador** without self-isolation.
+**Nova Scotia, New Brunswick, Prince Edward Island, Newfoundland, and Labrador**: [Interprovincial travel](https://globalnews.ca/news/7102105/nb-covid-19-update-june-24/) is allowed without self-isolation.
 
 
 For the most up-to-date travel information, refer to the [Canada Border Services Agency](https://www.cbsa-asfc.gc.ca/services/covid/non-canadians-canadiens-eng.html).

--- a/public/data/CA_domestic.md
+++ b/public/data/CA_domestic.md
@@ -1,3 +1,12 @@
-**Domestic travel is allowed with travel restrictions.** From March 30, 2020, all travelers flying in Canada will be subject to a health check before boarding. Travelers may be subject to additional provincial or territorial public health measures at their final destination.
+**Domestic travel is allowed with travel restrictions are in place.** From March 30, 2020, all travelers flying in Canada will be subject to a health check before boarding. 
+
+Travelers are subject to additional provincial or territorial public health measures at their final destination.
+
+**British Columbia**: The government has extended the state of emergency until July 6, 2020.
+
+**Ontario**: The government has extended the state of emergency until July 15, 2020. 
+
+[Interprovincial travel](https://globalnews.ca/news/7102105/nb-covid-19-update-june-24/) is allowed between **Nova Scotia, New Brunswick, Prince Edward Island, Newfoundland, and Labrador** without self-isolation.
+
 
 For the most up-to-date travel information, refer to the [Canada Border Services Agency](https://www.cbsa-asfc.gc.ca/services/covid/non-canadians-canadiens-eng.html).

--- a/public/data/CA_domestic.md
+++ b/public/data/CA_domestic.md
@@ -4,7 +4,7 @@ Travelers are subject to additional provincial or territorial public health meas
 
 **British Columbia**: The government has extended the state of emergency until July 6, 2020.
 
-**Ontario**: The government has extended the state of emergency until July 15, 2020. 
+**Ontario**: The government has extended the state of emergency until July 15, 2020.
 
 [Interprovincial travel](https://globalnews.ca/news/7102105/nb-covid-19-update-june-24/) is allowed between **Nova Scotia, New Brunswick, Prince Edward Island, Newfoundland, and Labrador** without self-isolation.
 

--- a/public/data/CA_domestic.md
+++ b/public/data/CA_domestic.md
@@ -1,4 +1,4 @@
-**Domestic travel is allowed with travel restrictions are in place.** From March 30, 2020, all travelers flying in Canada will be subject to a health check before boarding. 
+**Domestic travel is allowed with travel restrictions are in place.** From March 30, 2020, all travelers flying in Canada will be subject to a health check before boarding.
 
 Travelers are subject to additional provincial or territorial public health measures at their final destination.
 
@@ -7,6 +7,5 @@ Travelers are subject to additional provincial or territorial public health meas
 **Ontario**: The government has extended the state of emergency until July 15, 2020.
 
 **Nova Scotia, New Brunswick, Prince Edward Island, Newfoundland, and Labrador**: [Interprovincial travel](https://globalnews.ca/news/7102105/nb-covid-19-update-june-24/) is allowed without self-isolation.
-
 
 For the most up-to-date travel information, refer to the [Canada Border Services Agency](https://www.cbsa-asfc.gc.ca/services/covid/non-canadians-canadiens-eng.html).


### PR DESCRIPTION
Update domestic travel restriction changes
- Interprovincial travel allowed for Nova Scotia, New Brunswick, Prince Edward Island and Newfoundland and Labrador without self-isolation.
- British Columbia and Ontario extending the state of emergency 

Sources:
[https://globalnews.ca/news/7102105/nb-covid-19-update-june-24/]
[https://www.garda.com/crisis24/news-alerts/354086/canada-authorities-extend-state-of-emergency-in-ontario-until-july-15-update-17]
[https://www.garda.com/crisis24/news-alerts/354061/canada-authorities-extend-state-of-emergency-in-british-columbia-until-july-7-update-16]