### PR TITLE
Organize info

### DIFF
--- a/src/assets/styles/index.css
+++ b/src/assets/styles/index.css
@@ -77,6 +77,8 @@ ol > li:not(:last-child) { @apply mb-2; }
   .panel__inner { @apply p-6; }
 }
 
+.panel p:last-child { @apply mb-0 }
+
 /**
 * This injects any component classes registered by plugins.
 **/

--- a/src/assets/styles/index.css
+++ b/src/assets/styles/index.css
@@ -30,7 +30,6 @@ h5 { @apply text-base font-medium mb-4; }
   h2,
   h2.country-header { @apply text-2xl; },
   h3 { @apply text-xl; }
-  h4 { @apply text-lg; }
 }
 
 p { @apply mb-4; }

--- a/src/components/CountryBody.vue
+++ b/src/components/CountryBody.vue
@@ -1,8 +1,10 @@
 <template>
-  <div>
-    <slot />
-    <div v-if="!!this.content">
-      <vue-markdown :source="content" :anchorAttributes='anchorAttributes'></vue-markdown>
+  <div class="panel">
+    <div class="panel__inner">
+      <slot />
+      <div v-if="!!this.content">
+        <vue-markdown :source="content" :anchorAttributes='anchorAttributes'></vue-markdown>
+      </div>
     </div>
   </div>
 </template>

--- a/src/components/CountrySources.vue
+++ b/src/components/CountrySources.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="panel">
     <div class="panel__inner">
-      <h2>Sources</h2>
+      <h3>Sources</h3>
       <ol v-if="sourcesList.length">
         <li v-for="source in sourcesList" :key="source">
           <vue-markdown

--- a/src/components/CovidStats.vue
+++ b/src/components/CovidStats.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="my-4 sm:my-6 md:my-8">
+  <div>
     <h3>COVID-19 Statistics</h3>
     <CovidStatsFigure :data="countryData.newCases">New confirmed cases</CovidStatsFigure>
     <CovidStatsFigure :data="countryData.totalCases">Total confirmed cases</CovidStatsFigure>

--- a/src/components/Disclaimer.vue
+++ b/src/components/Disclaimer.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="panel">
     <div class="panel__inner">
-      <h2>Disclaimer</h2>
+      <h3>Disclaimer</h3>
       <p class="mb-0">
         Advisories may change without warning. Please check official government
         websites for up-to-date information on travel restrictions prior to your

--- a/src/components/TravelState.vue
+++ b/src/components/TravelState.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="state" class="my-4 sm:my-6 md:my-8">
+  <div v-if="state">
     <h3>Travel Status</h3>
     <div class="inline-grid grid-cols-legend row-gap-2 col-gap-4 items-baseline">
       <span>Domestic</span>

--- a/src/views/Country.vue
+++ b/src/views/Country.vue
@@ -12,27 +12,31 @@
               <p class="inline-flex mr-1 mb-0 font-semibold text-sm">
                 Want the latest travel updates in your inbox?
               </p>
-              <router-link :to="{ name: 'Subscribe'}" class="inline-flex font-semibold text-sm">
+              <router-link :to="{name: 'Subscribe'}" class="inline-flex font-semibold text-sm">
                 Subscribe here →
               </router-link>
             </div>
             <h2 class="country-header">{{title}}</h2>
-            <div class="blck md:flex mb-4">
-              <TravelState :country="country" class='w-full md:w-1/2' />
-              <CovidStats :country="country" class='w-full md:w-1/2' />
-            </div>
-            <div v-if='domesticContent || internationalContent || visaQuarantineContent'>
-              <CountryBody :content="this.domesticContent">
-                <h3>Domestic Travel</h3>
-              </CountryBody>
-              <CountryBody :content="this.internationalContent">
-                <h3>International Travel</h3>
-              </CountryBody>
-              <CountryBody :content="this.visaQuarantineContent">
-                <h3>Visa &amp; Quarantine Measures</h3>
-              </CountryBody>
+            <div class="mt-6 md:flex">
+              <div class="md:order-1">
+                <TravelState :country="country" />
+              </div>
+              <div class="md:order-0 w-full md:w-1/2 mt-6 md:mt-0 md:mr-4">
+                <CovidStats :country="country" />
+              </div>
             </div>
           </div>
+        </div>
+        <div v-if='domesticContent || internationalContent || visaQuarantineContent'>
+          <CountryBody :content="internationalContent">
+            <h3>International Travel</h3>
+          </CountryBody>
+          <CountryBody :content="domesticContent">
+            <h3>Domestic Travel</h3>
+          </CountryBody>
+          <CountryBody :content="visaQuarantineContent">
+            <h3>Visa &amp; Quarantine Measures</h3>
+          </CountryBody>
         </div>
         <div class="panel">
           <div class="panel__inner">


### PR DESCRIPTION
- Decrease `font-size` for `<h4>` so they don't look the same as `<h3>`
- Fix `<h2>` elements that should be `<h3>`
- Move `International` content above `Domestic`
- Break up info into panels