### PR TITLE
Abbreviate month names

### DIFF
--- a/src/components/CovidStatsFigure.vue
+++ b/src/components/CovidStatsFigure.vue
@@ -57,7 +57,7 @@ export default {
       svg.append('g')
         .attr('class', 'xaxis')
         .attr('transform', `translate(0, ${height})`)
-        .call(axisBottom(x).tickFormat(timeFormat('%B')));
+        .call(axisBottom(x).tickFormat(timeFormat('%b')));
 
       // Add Y axis
       const y = scaleLinear()


### PR DESCRIPTION
Abbreviate month names for COVID-19 statistics charts

<img width="455" alt="Screenshot 2020-07-23 at 4 57 46 PM" src="https://user-images.githubusercontent.com/26620750/88268904-b9906500-cd05-11ea-9ea6-e5d9938a1e9d.png">
