### PR TITLE
Border reopening date

### DIFF
--- a/src/assets/styles/components/_badge.scss
+++ b/src/assets/styles/components/_badge.scss
@@ -1,0 +1,13 @@
+.badge {
+  @apply
+  py-0.5 px-2.5
+  text-base text-center text-gray-800
+  rounded-md
+  whitespace-no-wrap;
+  &--xs { @apply text-xs; }
+  &--no { @apply bg-secondary text-white; }
+  &--yes { @apply bg-state-open text-white; }
+  &--selected { @apply bg-primary text-white; }
+  &--partial { @apply bg-state-partial; }
+  &--unknown { @apply bg-gray-400; }
+};

--- a/src/assets/styles/components/index.scss
+++ b/src/assets/styles/components/index.scss
@@ -1,2 +1,3 @@
+@import "badge";
 @import "button";
 @import "main_container";

--- a/src/components/CovidStats/Panel.vue
+++ b/src/components/CovidStats/Panel.vue
@@ -2,7 +2,10 @@
   <div>
     <div class="md:flex">
       <div class="md:order-1">
-        <TravelState :country="country" />
+        <div class="flex flex-col">
+          <TravelState :country="country" />
+          <ReopeningDate :country="country" class="mt-8" />
+        </div>
       </div>
       <div class="md:order-0 w-full md:w-1/2 mt-8 md:mt-0 md:mr-8">
         <h3>COVID-19 Statistics</h3>
@@ -12,11 +15,11 @@
       </div>
     </div>
     <p class="text-xs">
-      <sup>*</sup>
-      Statistics are published by
+      <sup>*</sup>Statistics are published by
       <a href="https://www.ecdc.europa.eu/en/covid-19-pandemic" target="_blank">
         European Centre for Disease Prevention and Control
-      </a><LastUpdatedOn :stats="stats.newCases" /></p>
+      </a><LastUpdatedOn :stats="stats.newCases" />
+    </p>
   </div>
 </template>
 
@@ -25,14 +28,16 @@
 
 import { csv, timeParse } from 'd3';
 import TravelState from '@/components/TravelState.vue';
-import LastUpdatedOn from './LastUpdatedOn.vue';
 import Graph from './Graph.vue';
+import LastUpdatedOn from './LastUpdatedOn.vue';
+import ReopeningDate from './ReopeningDate.vue';
 
 export default {
   components: {
-    LastUpdatedOn,
-    Graph,
     TravelState,
+    Graph,
+    LastUpdatedOn,
+    ReopeningDate,
   },
   data() {
     return {

--- a/src/components/CovidStats/ReopeningDate.vue
+++ b/src/components/CovidStats/ReopeningDate.vue
@@ -1,0 +1,28 @@
+<template>
+  <div v-if="reopeningDate">
+    <h3>{{country.name}} Border Reopening</h3>
+    <div class="inline-grid grid-cols-legend row-gap-2 col-gap-4 items-baseline">
+      <span>Forecasted</span>
+      <span class="badge badge--yes">{{reopeningDate}}</span>
+    </div>
+  </div>
+</template>
+
+<script>
+import { findCountryReopeningDate } from '@/constants/travel';
+import moment from 'moment';
+
+export default {
+  name: 'ReopeningDate',
+  props: {
+    country: Object,
+  },
+  computed: {
+    reopeningDate() {
+      const date = findCountryReopeningDate(this.country.code);
+      if (!date) { return false; }
+      return moment(date).format('MMMM D, YYYY');
+    },
+  },
+};
+</script>

--- a/src/components/TravelStateBadge.vue
+++ b/src/components/TravelStateBadge.vue
@@ -29,30 +29,3 @@ export default {
   },
 };
 </script>
-
-<style lang="scss">
-.badge {
-  @apply py-0.5 px-2.5 text-base text-center rounded-md whitespace-no-wrap;
-  &--xs { @apply text-xs }
-  &--no {
-    @apply bg-secondary;
-    @apply text-white;
-  }
-  &--partial {
-    @apply bg-state-partial;
-    @apply text-gray-800;
-  }
-  &--selected {
-    @apply bg-primary;
-    @apply text-white;
-  }
-  &--unknown {
-    @apply bg-gray-400;
-    @apply text-gray-800;
-  }
-  &--yes {
-    @apply bg-state-open;
-    @apply text-white;
-  }
-};
-</style>

--- a/src/constants/travel.ts
+++ b/src/constants/travel.ts
@@ -44,3 +44,9 @@ export function findSourcesForCountry(countryCode: string) {
 export function findTravelIdeasForCountry(countryCode: string) {
   return Object.values(countries[countryCode]?.travel_ideas || []);
 }
+
+
+export function findCountryReopeningDate(countryCode: string) {
+  const date = Object.keys(countries[countryCode]?.reopening || []);
+  return (!date.length ? false : Date.parse(date[0]));
+}


### PR DESCRIPTION
- Find the country reopening date
- Create `ReopeningDate` component
- Render `ReopeningDate` component
- Extract `badge` CSS styles into a CSS component

<img width="877" alt="Screenshot 2020-07-30 at 1 29 32 PM" src="https://user-images.githubusercontent.com/26620750/88887188-7d618500-d26e-11ea-8c9f-4fdecb004a05.png">
<img width="531" alt="Screenshot 2020-07-30 at 1 29 43 PM" src="https://user-images.githubusercontent.com/26620750/88887196-80f50c00-d26e-11ea-929e-bc1e4830ccbc.png">
